### PR TITLE
Allow merge commits

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -28,7 +28,10 @@ repository:
 
   # Either `true` to allow merging pull requests with a merge commit, or `false`
   # to prevent merging pull requests with merge commits.
-  allow_merge_commit: false
+  #
+  # We need merge commits to automatically merge PRs for infra-demo repositories
+  # created by refarch-scaffold
+  allow_merge_commit: true
 
   # Either `true` to allow rebase-merging pull requests, or `false` to prevent
   # rebase-merging.


### PR DESCRIPTION
## what

Allow merge commits. Setting `allow_merge_commit: true`

## why

We use merge commits to merge in PRs from refarch-scaffold into the demo repositories.  If not enabled, these workflows fail:

```console
[2024-03-29T17:55:40+0000] merging pull request...
GraphQL: Merge commits are not allowed on this repository. (mergePullRequest)
Error: Process completed with exit code 1.
```

## ref
https://github.com/cloudposse/refarch-scaffold/actions/runs/8483960840/job/23246024848
